### PR TITLE
Mnemnion patch strict

### DIFF
--- a/reflect.lua
+++ b/reflect.lua
@@ -33,7 +33,15 @@ local function gc_str(gcref) -- Convert a GCref (to a GCstr) into a string
   end
 end
 
-local typeinfo = ffi.typeinfo or function(id)
+local typeinfo
+
+if jit and jit.version == "LuaJIT 2.0.5" then
+   typeinfo = false
+else
+   typeinfo = assert(ffi.typeinfo, "Must have LuaJIT > 2.0.5")
+end
+
+typeinfo = typeinfo or function(id)
   -- ffi.typeof is present in LuaJIT v2.1 since 8th Oct 2014 (d6ff3afc)
   -- this is an emulation layer for older versions of LuaJIT
   local ctype = (CTState or init_CTState()).tab[id]

--- a/reflect.lua
+++ b/reflect.lua
@@ -33,13 +33,7 @@ local function gc_str(gcref) -- Convert a GCref (to a GCstr) into a string
   end
 end
 
-local typeinfo
-
-if jit and jit.version == "LuaJIT 2.0.5" then
-   typeinfo = false
-else
-   typeinfo = assert(ffi.typeinfo, "Must have LuaJIT >= 2.0.5")
-end
+local typeinfo = rawget(ffi, "typeinfo")
 
 typeinfo = typeinfo or function(id)
   -- ffi.typeof is present in LuaJIT v2.1 since 8th Oct 2014 (d6ff3afc)

--- a/reflect.lua
+++ b/reflect.lua
@@ -38,7 +38,7 @@ local typeinfo
 if jit and jit.version == "LuaJIT 2.0.5" then
    typeinfo = false
 else
-   typeinfo = assert(ffi.typeinfo, "Must have LuaJIT > 2.0.5")
+   typeinfo = assert(ffi.typeinfo, "Must have LuaJIT >= 2.0.5")
 end
 
 typeinfo = typeinfo or function(id)


### PR DESCRIPTION
The original way of detecting typeinfo is not compatible with a 'strict' mode to modules a la Penlight.

This patch detects the circumstance leading to the emulation layer function without performing a nil field access.
